### PR TITLE
Fix modmail + update ban message

### DIFF
--- a/src/plugins/cases/Case.model.ts
+++ b/src/plugins/cases/Case.model.ts
@@ -85,7 +85,7 @@ caseSchema.pre("save", async function () {
         const user = await useClient().users.fetch(this.target);
         const guild = await useClient().guilds.fetch(this.guild);
         await user.send(
-            `You have been ${friendlyNames.get(this.type)} ${guild.name}${this.reason ? ` for ${inlineCode(this.reason)}` : ""}.${this.duration ? ` Expiry: ${time(new Date(parseInt(this.createdAtTimestamp) + this.duration), TimestampStyles.RelativeTime)}` : ""}${this.type === CaseType.BAN ? "\nAppeal at https://rapple.xyz/appeals" : ""}`,
+            `You have been ${friendlyNames.get(this.type)} ${guild.name}${this.reason ? ` for ${inlineCode(this.reason)}` : ""}.${this.duration ? ` Expiry: ${time(new Date(parseInt(this.createdAtTimestamp) + this.duration), TimestampStyles.RelativeTime)}` : ""}${this.type === CaseType.BAN ? "\nAppeal by joining https://discord.gg/v6eVy5AFF8 and messaging the G'day bot." : ""}`,
         );
         this.userNotified = true;
     } catch {

--- a/src/plugins/modmail/MailThread.ts
+++ b/src/plugins/modmail/MailThread.ts
@@ -60,15 +60,17 @@ mailThreadSchema.pre("save", async function () {
 mailThreadSchema.post("save", async function () {
     try {
         const resolvedAuthor = await useClient().users.fetch(this.author);
-        const initialMessage = await resolvedAuthor.dmChannel?.messages.fetch(
-            this.initialMessage as Snowflake,
+        const dmChannel = resolvedAuthor.dmChannel || await resolvedAuthor.createDM();
+
+        const initialMessage = await dmChannel.messages.fetch(
+            this.initialMessage as Snowflake
         );
+
         if (initialMessage) {
             await forwardModmailMessage(initialMessage);
         }
-    } catch {
-        console.log("errored");
-        //ignored
+    } catch (err) {
+        console.error("Error in mailThreadSchema post-save:", err);
     }
 });
 


### PR DESCRIPTION
See PR descriptions for specific changes. 

- Updates dead link for ban messages from rapple.xyz to a direct Discord guild invite.
- Fixes an issue where 'initialMessage' returns null, so the first message in a modmail thread is not sent to the thread.